### PR TITLE
Fix duplicate wrap-up in blog content generation

### DIFF
--- a/services/content_generator.py
+++ b/services/content_generator.py
@@ -372,9 +372,11 @@ class ContentGenerator:
             if holistic_intro:
                 markdown = self._insert_holistic_intro(markdown, holistic_intro)
             
-            wrap_up = ai_service.make_wrap_up(self.target_date, inputs, force_ai)
-            if wrap_up:
-                markdown = self._insert_wrap_up(markdown, wrap_up)
+            # Only generate wrap-up if one doesn't already exist in frontmatter
+            if not self.frontmatter.get("wrap_up"):
+                wrap_up = ai_service.make_wrap_up(self.target_date, inputs, force_ai)
+                if wrap_up:
+                    markdown = self._insert_wrap_up(markdown, wrap_up)
             
             # 5. Generate AI-suggested tags
             suggested_tags = ai_service.suggest_tags(self.target_date, inputs, force_ai)


### PR DESCRIPTION
- Prevent AI post-processing from generating wrap-up when one already exists in frontmatter
- Eliminates duplicate wrap-up paragraphs in blog content
- Wrap-up now appears once at the end of content as intended
- Improves content quality and readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Wrap-up content is generated and inserted only when absent, eliminating accidental duplicates in posts that already include a wrap-up in their metadata. Ensures cleaner final output.
- Performance
  - Avoids unnecessary AI calls when a wrap-up is already present, improving generation speed and lowering resource consumption during post-processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->